### PR TITLE
two simple inclusion changes

### DIFF
--- a/CCS/Guadaloop_lib/guadaloop/lib/i2c/i2c_read_write.c
+++ b/CCS/Guadaloop_lib/guadaloop/lib/i2c/i2c_read_write.c
@@ -7,7 +7,6 @@
  *
  * */
 #include <stdint.h>
-#include "msp432e401y.h"
 #include <guadaloop/lib/i2c/i2c_read_write.h>
 
 /** MACROS **/

--- a/CCS/Guadaloop_lib/guadaloop/lib/i2c/i2c_read_write.h
+++ b/CCS/Guadaloop_lib/guadaloop/lib/i2c/i2c_read_write.h
@@ -25,6 +25,7 @@
 
 #ifndef I2C_READ_WRITE_H_
 #define I2C_READ_WRITE_H_
+#include "msp432e401y.h"
 
 /**
  * enumeration of I2C modules on MSP432


### PR DESCRIPTION
fixes the simple issue where we have an inclusion in the .c file but not in the header file, this was causing build errors